### PR TITLE
Prevent duplicate word names

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,6 +16,10 @@ class ApplicationController < ActionController::API
     render_error_response(400, e)
   end
 
+  rescue_from 'ActiveRecord::RecordInvalid' do |e|
+    render_error_response(422, e)
+  end
+
   rescue_from 'ActiveRecord::RecordNotFound' do |e|
     render_error_response(404, e)
   end

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -32,7 +32,7 @@ class CategoriesController < ApplicationController
     raise_error ArgumentError.new('No category params provided') if category_params.empty?
     return Category.find_by(name: category_params[:name]) if Category.exists?(name: category_params[:name])
 
-    Category.create(category_params)
+    Category.create!(category_params)
   end
 
   def wordlist_entry_categories_params

--- a/app/controllers/wordlist_entries_controller.rb
+++ b/app/controllers/wordlist_entries_controller.rb
@@ -42,12 +42,10 @@ class WordlistEntriesController < ApplicationController
   private
 
   def find_or_create_word
-    word_id = params[:wordlist_entry][:word][:id]
-    word_name = params[:wordlist_entry][:word][:name]
-    word = if word_id
-             Word.find(word_id)
+    word = if word_params[:id]
+             Word.find(word_params[:id])
            else
-             Word.find_by(name: word_name)
+             Word.find_by(name: word_params[:name])
            end
 
     word || Word.create!(word_params)
@@ -78,7 +76,7 @@ class WordlistEntriesController < ApplicationController
   end
 
   def word_params
-    params.require(:wordlist_entry).permit(word: :name)[:word]
+    params.require(:wordlist_entry).permit(word: [:id, :name])[:word]
   end
 
   def wordlist_entry_id_valid?(id)

--- a/app/controllers/wordlist_entries_controller.rb
+++ b/app/controllers/wordlist_entries_controller.rb
@@ -12,7 +12,7 @@ class WordlistEntriesController < ApplicationController
     @wordlist_id = wordlist.id
 
     word = find_or_create_word
-    wordlist_entry = WordlistEntry.create(wordlist_entry_params(word.id, @wordlist_id))
+    wordlist_entry = WordlistEntry.create!(wordlist_entry_params(word.id, @wordlist_id))
 
     render json: {
       data: {
@@ -50,7 +50,7 @@ class WordlistEntriesController < ApplicationController
              Word.find_by(name: word_name)
            end
 
-    word || Word.create(word_params)
+    word || Word.create!(word_params)
   end
 
   def parse_wordlist_entries(wordlist_entries)

--- a/app/controllers/wordlists_controller.rb
+++ b/app/controllers/wordlists_controller.rb
@@ -4,8 +4,7 @@ class WordlistsController < ApplicationController
   include TokenHelper
 
   def create
-    wordlist = Wordlist.new(user_id: @user_id)
-    return unless wordlist.save
+    wordlist = Wordlist.create!(user_id: @user_id)
 
     response.status = 201
     render json: {

--- a/app/models/word.rb
+++ b/app/models/word.rb
@@ -3,6 +3,15 @@ class Word < ApplicationRecord
   has_many :categories, through: :wordlist_entries
   has_many :wordlist_entries
   has_many :wordlists, through: :wordlist_entries
+  validate :id_not_changed
   validates :name, presence: true
   validates_uniqueness_of :name
+
+  private
+
+  def id_not_changed
+    return unless id_changed? && persisted?
+
+    errors.add(:id, "can't be updated")
+  end
 end

--- a/app/models/wordlist.rb
+++ b/app/models/wordlist.rb
@@ -2,6 +2,15 @@ class Wordlist < ApplicationRecord
   self.implicit_order_column = 'created_at'
   has_many :wordlist_entries
   has_many :words, through: :wordlist_entries
+  validate :id_not_changed
   validates :user_id, presence: true
   validates_uniqueness_of :user_id
+
+  private
+
+  def id_not_changed
+    return unless id_changed? && persisted?
+
+    errors.add(:id, "can't be updated")
+  end
 end

--- a/app/models/wordlist_entry.rb
+++ b/app/models/wordlist_entry.rb
@@ -8,6 +8,7 @@ class WordlistEntry < ApplicationRecord
 
   validate :id_not_changed
   validates :word_id, presence: true
+  validate :word_is_unique_to_wordlist
   validates :wordlist_id, presence: true
 
   private
@@ -16,5 +17,11 @@ class WordlistEntry < ApplicationRecord
     return unless id_changed? && persisted?
 
     errors.add(:id, "can't be updated")
+  end
+
+  def word_is_unique_to_wordlist
+    return unless wordlist.wordlist_entries.any? { |entry| entry.word.name == word.name }
+
+    errors.add(:word, 'name not unique to Wordlist')
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -37,13 +37,15 @@ FactoryBot.define do
 end
 
 def wordlist_with_wordlist_entries_with_categories(wordlist_entries_count: 2)
-  FactoryBot.create(:wordlist) do |wordlist|
+  FactoryBot.create(:wordlist).then do |wordlist|
     FactoryBot.create_list(:wordlist_entry_with_categories, wordlist_entries_count, wordlist: wordlist)
+    Wordlist.last
   end
 end
 
 def wordlist_with_wordlist_entries_no_categories(wordlist_entries_count: 2)
-  FactoryBot.create(:wordlist) do |wordlist|
+  FactoryBot.create(:wordlist).then do |wordlist|
     FactoryBot.create_list(:wordlist_entry, wordlist_entries_count, wordlist: wordlist)
+    Wordlist.last
   end
 end

--- a/spec/factories_spec.rb
+++ b/spec/factories_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe '#wordlist_with_wordlist_entries_with_categories' do
+  it 'creates 1 Wordlist' do
+    expect { wordlist_with_wordlist_entries_with_categories }.to change { Wordlist.count }.by 1
+  end
+
+  it 'creates 2 WordlistEntries' do
+    expect { wordlist_with_wordlist_entries_with_categories }.to change { WordlistEntry.count }.by 2
+  end
+
+  it 'WordlistEntries are unique' do
+    expect(WordlistEntry.count).to eq 0
+    wordlist_with_wordlist_entries_with_categories
+    expect(WordlistEntry.all[0].id == WordlistEntry.all[1].id).to be false
+  end
+
+  it 'creates 6 categories' do
+    expect { wordlist_with_wordlist_entries_with_categories }.to change { Category.count }.by 6
+  end
+
+  it 'created Wordlist has the two created WordlistEntries' do
+    expect(WordlistEntry.count).to eq 0
+    wl = wordlist_with_wordlist_entries_with_categories
+    expect(wl.wordlist_entries).to eq([WordlistEntry.all[0], WordlistEntry.all[1]])
+  end
+
+  it 'the WordlistEntries have 3 Categories each' do
+    wl = wordlist_with_wordlist_entries_with_categories
+    expect(wl.wordlist_entries.first.categories.count).to eq 3
+    expect(wl.wordlist_entries.second.categories.count).to eq 3
+  end
+end
+
+RSpec.describe '#wordlist_with_wordlist_entries_no_categories' do
+  it 'creates 1 Wordlist' do
+    expect { wordlist_with_wordlist_entries_no_categories }.to change { Wordlist.count }.by 1
+  end
+
+  it 'creates 2 WordlistEntries' do
+    expect { wordlist_with_wordlist_entries_no_categories }.to change { WordlistEntry.count }.by 2
+  end
+
+  it 'WordlistEntries are unique' do
+    expect(WordlistEntry.count).to eq 0
+    wordlist_with_wordlist_entries_no_categories
+    expect(WordlistEntry.all[0].id == WordlistEntry.all[1].id).to be false
+  end
+
+  it 'created Wordlist has the two created WordlistEntries' do
+    expect(WordlistEntry.count).to eq 0
+    wl = wordlist_with_wordlist_entries_no_categories
+    expect(wl.wordlist_entries).to eq([WordlistEntry.all[0], WordlistEntry.all[1]])
+  end
+end

--- a/spec/models/word_spec.rb
+++ b/spec/models/word_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe Word, type: :model do
+  let(:word) do
+    described_class.create!(name: 'table')
+  end
+
+  context 'when an id is not provided during creation' do
+    it 'an id is generated on creation' do
+      expect(word.id).to_not be nil
+    end
+
+    it 'id is different between instances' do
+      word2 = described_class.create!(name: 'hound')
+      expect(word.id).to_not eq word2.id
+    end
+
+    it 'cannot be saved without a name' do
+      expect do
+        described_class.create!
+      end.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Name can't be blank")
+    end
+  end
+
+  context 'when an id is provided during creation' do
+    let(:uuid) { '79c9bc0f-8ecf-4cf7-a05e-7c485d02078d' }
+    let(:word2) { described_class.create!(id: uuid, name: 'banshee') }
+
+    it 'is given the provided id' do
+      expect(word2.id).to eq '79c9bc0f-8ecf-4cf7-a05e-7c485d02078d'
+    end
+
+    it "if id isn't a valid UUID, one is created" do
+      w = described_class.create!(id: 'bogus-id', name: 'baskerville')
+      expect(VALID_UUID_REGEX.match?(w.id)).to be true
+    end
+
+    it 'id must be unique' do
+      expect do
+        described_class.create!(id: word2.id, name: 'dawg')
+      end.to raise_error(ActiveRecord::RecordNotUnique)
+    end
+
+    it 'cannot be saved without a name' do
+      expect do
+        described_class.create!(id: SecureRandom.uuid)
+      end.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Name can't be blank")
+    end
+  end
+
+  it "an instance's id cannot be updated" do
+    expect { word.update!(id: SecureRandom.uuid) }.to raise_error(
+      ActiveRecord::RecordInvalid, "Validation failed: Id can't be updated"
+    )
+  end
+
+  it 'is searchable by the id' do
+    expect(described_class.find(word.id)).to eq(word)
+  end
+
+end

--- a/spec/models/word_spec.rb
+++ b/spec/models/word_spec.rb
@@ -57,5 +57,4 @@ RSpec.describe Word, type: :model do
   it 'is searchable by the id' do
     expect(described_class.find(word.id)).to eq(word)
   end
-
 end

--- a/spec/models/wordlist_entry_spec.rb
+++ b/spec/models/wordlist_entry_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe WordlistEntry, type: :model do
       expect do
         described_class.create!(
           id: wordlist_entry2.id,
-          word_id: word.id,
+          word_id: create(:word).id,
           wordlist_id: wordlist.id
         )
       end.to raise_error(ActiveRecord::RecordNotUnique)

--- a/spec/models/wordlist_spec.rb
+++ b/spec/models/wordlist_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe Wordlist, type: :model do
+  let(:wordlist) { described_class.create!(user_id: SecureRandom.uuid) }
+
+  context 'when an id is not provided during creation' do
+    it 'an id is generated on creation' do
+      expect(wordlist.id).to_not be_nil
+    end
+
+    it 'id is different between instances' do
+      wordlist2 = described_class.create!(user_id: SecureRandom.uuid)
+      expect(wordlist.id).to_not eq wordlist2.id
+    end
+
+    it 'cannot be saved if user_id already has a Wordlist associated with it' do
+      expect do
+        described_class.create!(user_id: wordlist.user_id)
+      end.to raise_error(ActiveRecord::RecordInvalid, 'Validation failed: User has already been taken')
+    end
+  end
+
+  context 'when an id is provided during creation' do
+    let(:uuid) { '79c9bc0f-8ecf-4cf7-a05e-7c485d02078d' }
+    let(:wordlist2) { described_class.create!(id: uuid, user_id: SecureRandom.uuid) }
+
+    it 'is given the provided id' do
+      expect(wordlist2.id).to eq '79c9bc0f-8ecf-4cf7-a05e-7c485d02078d'
+    end
+
+    it "if id isn't a valid UUID, one is created" do
+      wl = described_class.create!(id: 'bogus-id', user_id: SecureRandom.uuid)
+      expect(VALID_UUID_REGEX.match?(wl.id)).to be true
+    end
+
+    it 'id must be unique' do
+      expect do
+        described_class.create!(id: wordlist2.id, user_id: SecureRandom.uuid)
+      end.to raise_error(ActiveRecord::RecordNotUnique)
+    end
+
+    it 'cannot be saved without a user_id' do
+      expect do
+        described_class.create!(id: SecureRandom.uuid)
+      end.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: User can't be blank")
+    end
+
+    it 'cannot be saved if user_id already has a Wordlist associated with it' do
+      expect do
+        described_class.create!(user_id: wordlist2.user_id)
+      end.to raise_error(ActiveRecord::RecordInvalid, 'Validation failed: User has already been taken')
+    end
+  end
+
+  it "an instance's id cannot be updated" do
+    expect { wordlist.update!(id: SecureRandom.uuid) }.to raise_error(
+      ActiveRecord::RecordInvalid, "Validation failed: Id can't be updated"
+    )
+  end
+
+  it 'is searchable by the id' do
+    expect(described_class.find(wordlist.id)).to eq(wordlist)
+  end
+end


### PR DESCRIPTION
Issue: https://github.com/Yorkshireman/my_wordlist_resources/issues/25

Prevent two WordlistEntries on the same Wordlist that would have identical Word names.

Also adds some model specs and some other optimisations.